### PR TITLE
Scope h1 changes to article and section

### DIFF
--- a/src/normalize.css
+++ b/src/normalize.css
@@ -38,7 +38,8 @@ body {
  * `article` contexts in Chrome, Firefox, and Safari.
  */
 
-h1 {
+article h1,
+section h1 {
     font-size: 2em;
     margin: 0.67em 0;
 }


### PR DESCRIPTION
Changes the normalize.css stylesheet to scope h1 `font-size` and `margin` to only article and section.

Before:
```
/**
 * Correct the font size and margin on `h1` elements within `section` and
 * `article` contexts in Chrome, Firefox, and Safari.
 */

h1 {
    font-size: 2em;
    margin: 0.67em 0;
}
```

After:
```
/**
 * Correct the font size and margin on `h1` elements within `section` and
 * `article` contexts in Chrome, Firefox, and Safari.
 */

article h1,
section h1 {
    font-size: 2em;
    margin: 0.67em 0;
}
```